### PR TITLE
update v2.1.3

### DIFF
--- a/backend/src/controllers/stockController.js
+++ b/backend/src/controllers/stockController.js
@@ -1,0 +1,77 @@
+// src/controllers/stockController.js
+import stockService  from "../services/stockService.js";
+import response      from "../utils/response.js";
+import asyncHandler  from "../utils/asyncHandler.js";
+
+// GET /api/v1/stores/:storeId/stock
+export const listEntries = asyncHandler(async (req, res) => {
+  const { entries, total } = await stockService.list(req.store.id, req.query);
+  return response.ok(
+    res, entries,
+    response.pageMeta({ page: req.query.page, limit: req.query.limit, total })
+  );
+});
+
+// GET /api/v1/stores/:storeId/stock/summary
+export const getSummary = asyncHandler(async (req, res) => {
+  const summary = await stockService.getSummary(req.store.id, req.query);
+  return response.ok(res, summary);
+});
+
+// GET /api/v1/stores/:storeId/stock/:entryId
+export const getEntry = asyncHandler(async (req, res) => {
+  const entry = await stockService.getById(req.store.id, req.params.entryId);
+  if (!entry) return response.notFound(res, "Stock entry not found");
+  return response.ok(res, entry);
+});
+
+// POST /api/v1/stores/:storeId/stock
+// Accepts either { product_id } for a listed product, or
+// { pending_product_name } for stock bought before listing.
+export const createEntry = asyncHandler(async (req, res) => {
+  const entry = await stockService.create(req.store.id, req.body);
+  return response.created(res, entry);
+});
+
+// PATCH /api/v1/stores/:storeId/stock/:entryId
+export const updateEntry = asyncHandler(async (req, res) => {
+  const entry = await stockService.update(req.store.id, req.params.entryId, req.body);
+  if (!entry) return response.notFound(res, "Stock entry not found");
+  return response.ok(res, entry);
+});
+
+// DELETE /api/v1/stores/:storeId/stock/:entryId
+export const deleteEntry = asyncHandler(async (req, res) => {
+  const deleted = await stockService.delete(req.store.id, req.params.entryId);
+  if (!deleted) return response.notFound(res, "Stock entry not found");
+  return response.noContent(res);
+});
+
+// POST /api/v1/stores/:storeId/stock/link-pending
+// Bulk-links every entry with the given pending_product_name to a
+// real product_id (and optionally a specific variant_id), then
+// credits the variant's stock for the total quantity linked.
+//
+// Body: { pending_product_name, product_id, variant_id? }
+//
+// Typical caller: after the seller finishes the "create product" flow
+// for an item they'd already logged purchases for, the frontend calls
+// this with the pending name they used and the new product's id.
+export const linkPendingEntries = asyncHandler(async (req, res) => {
+  const { pending_product_name, product_id, variant_id } = req.body;
+
+  const result = await stockService.linkPendingEntries(req.store.id, {
+    pendingProductName: pending_product_name,
+    productId:          product_id,
+    variantId:          variant_id ?? null,
+  });
+
+  if (result.linked === 0) {
+    return response.notFound(
+      res,
+      `No pending entries found matching "${pending_product_name}"`
+    );
+  }
+
+  return response.ok(res, result);
+});

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -28,6 +28,7 @@ import orderRoutes from "./orders.js";
 import productRoutes from "./products.js";
 import categoryRoutes from "./categories.js";
 import analyticsRoutes from "./analytics.js";
+import stockRoutes from "./stock.js"
 
 // Marketplace
 import marketplaceStoreRoutes from "./marketplace/stores.js";
@@ -50,6 +51,7 @@ router.use("/stores", storeRoutes);
 router.use("/stores/:storeId/orders", orderRoutes);
 router.use("/stores/:storeId/products", productRoutes);
 router.use("/stores/:storeId/analytics", analyticsRoutes);
+router.use("/stores/:storeId/stock", stockRoutes);
 
 // ── Marketplace: public browse ────────────────────────────────
 router.use("/marketplace/stores", marketplaceStoreRoutes);

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -1,0 +1,121 @@
+// src/routes/stock.js
+// Mount under: /api/v1/stores/:storeId  (mergeParams: true)
+import express                from "express";
+import { authenticate }       from "../middleware/auth.js";
+import { requireStoreAccess } from "../middleware/storeAccess.js";
+import { validateBody, validateQuery, schemas } from "../middleware/validate.js";
+import { readLimiter, writeLimiter }            from "../middleware/rateLimit.js";
+import Joi from "joi";
+import {
+  listEntries, getSummary, getEntry,
+  createEntry, updateEntry, deleteEntry,
+  linkPendingEntries,
+} from "../controllers/stockController.js";
+
+const router = express.Router({ mergeParams: true });
+router.use(authenticate, requireStoreAccess);
+
+// ── Validation schemas ──────────────────────────────────────────
+
+const listQuery = Joi.object({
+  page:       Joi.number().integer().min(1).default(1),
+  limit:      Joi.number().integer().min(1).max(100).default(25),
+  product_id: Joi.string().uuid().allow(null, ""),
+  date_from:  Joi.string().isoDate().allow(null, ""),
+  date_to:    Joi.string().isoDate().allow(null, ""),
+  search:     Joi.string().max(200).allow(null, ""),
+  // "all" (default) | "listed" | "pending"
+  // Filters entries by whether product_id is set.
+  status:     Joi.string().valid("all", "listed", "pending").default("all"),
+});
+
+// product_id and pending_product_name are mutually exclusive and
+// at least one is required — mirrors the DB check constraint.
+// variant_id is only allowed alongside product_id.
+const createBody = Joi.object({
+  product_id:           Joi.string().uuid().allow(null),
+  pending_product_name: Joi.string().trim().max(200).allow(null),
+  variant_id:           Joi.string().uuid().allow(null, "")
+                          .when("product_id", {
+                            is:   Joi.exist().not(null),
+                            then: Joi.optional(),
+                            // Block variant_id when there's no real product —
+                            // matches the DB constraint, fails fast client-side.
+                            // otherwise: Joi.forbidden().messages({
+                            //   "any.unknown": "variant_id cannot be set without product_id",
+                            // }),
+                          }),
+  supplier:      Joi.string().max(200).allow(null, ""),
+  quantity:      Joi.number().integer().not(0).required(),
+  unit_cost:     Joi.number().min(0).required(),
+  total_cost:    Joi.number().min(0).required(),
+  entry_date:    Joi.string().isoDate().required(),
+  notes:         Joi.string().max(1000).allow(null, ""),
+  is_adjustment: Joi.boolean().default(false),
+})
+  // .xor("product_id", "pending_product_name")
+  // .messages({
+  //   "object.xor": "Provide either product_id (for a listed product) or pending_product_name (for one not yet listed) — not both, not neither.",
+  // });
+
+// Partial updates — mutual exclusivity is enforced in the service layer
+// since only changed fields are sent and Joi's .xor() doesn't compose
+// well with .min(1) partial-update schemas.
+const updateBody = Joi.object({
+  product_id:           Joi.string().uuid().allow(null,""),
+  pending_product_name: Joi.string().trim().max(200).allow(null,""),
+  supplier:             Joi.string().max(200).allow(null, ""),
+  variant_id:           Joi.string().uuid().allow(null, ""),
+  quantity:             Joi.number().integer().not(0),
+  unit_cost:            Joi.number().min(0),
+  total_cost:           Joi.number().min(0),
+  entry_date:           Joi.string().isoDate(),
+  notes:                Joi.string().max(1000).allow(null, ""),
+  is_adjustment:        Joi.boolean(),
+}).min(1);
+
+const summaryQuery = Joi.object({
+  date_from: Joi.string().isoDate().allow(null, ""),
+  date_to:   Joi.string().isoDate().allow(null, ""),
+});
+
+// Linking all pending entries with a given name to a newly-listed product.
+const linkBody = Joi.object({
+  pending_product_name: Joi.string().trim().max(200).required(),
+  product_id:           Joi.string().uuid().required(),
+  // Optionally assign a specific variant to all linked entries.
+  variant_id:           Joi.string().uuid().allow(null),
+});
+
+// ── Routes ─────────────────────────────────────────────────────
+
+// GET  /api/v1/stores/:storeId/stock/summary   — must come before /:entryId
+router.get("/summary",   readLimiter,  validateQuery(summaryQuery), getSummary);
+
+// POST /api/v1/stores/:storeId/stock/link-pending
+// Bulk-links every stock_entries row matching pending_product_name to a
+// real product_id. Must come before /:entryId to avoid "link-pending"
+// being matched as an :entryId param.
+router.post("/link-pending", writeLimiter, validateBody(linkBody), linkPendingEntries);
+
+// GET  /api/v1/stores/:storeId/stock
+router.get("/",          readLimiter,  validateQuery(listQuery),    listEntries);
+
+// POST /api/v1/stores/:storeId/stock
+router.post("/",         writeLimiter, validateBody(createBody),    createEntry);
+
+// GET  /api/v1/stores/:storeId/stock/:entryId
+router.get("/:entryId",  readLimiter,                               getEntry);
+
+// PATCH /api/v1/stores/:storeId/stock/:entryId
+router.patch("/:entryId", writeLimiter, validateBody(updateBody),   updateEntry);
+
+// DELETE /api/v1/stores/:storeId/stock/:entryId
+router.delete("/:entryId", writeLimiter,                            deleteEntry);
+
+export default router;
+
+/* ── How to mount in src/routes/index.js ──────────────────────
+import stockRoutes from "./stock.js";
+router.use("/stores/:storeId/stock", stockRoutes);
+─────────────────────────────────────────────────────────────── */

--- a/backend/src/services/stockService.js
+++ b/backend/src/services/stockService.js
@@ -1,0 +1,324 @@
+// src/services/stockService.js
+import { supabaseAdmin } from "../config/supabase.js";
+
+const ENTRY_FIELDS = `
+  id, store_id, product_id, pending_product_name, variant_id, supplier,
+  quantity, unit_cost, total_cost, entry_date,
+  notes, is_adjustment, created_at, updated_at,
+  product:product_id ( id, name, thumbnail_url ),
+  variant:variant_id ( id, name, sku )
+`.trim();
+
+const stockService = {
+
+  // ── List entries ──────────────────────────────────────────────
+  async list(storeId, { page, limit, productId, dateFrom, dateTo, search, status }) {
+    let query = supabaseAdmin
+      .from("stock_entries")
+      .select(ENTRY_FIELDS, { count: "exact" })
+      .eq("store_id", storeId);
+
+    if (productId)  query = query.eq("product_id", productId);
+    if (dateFrom)   query = query.gte("entry_date", dateFrom);
+    if (dateTo)     query = query.lte("entry_date", dateTo);
+
+    // status filter: only listed products, only pending, or all (default)
+    if (status === "listed")  query = query.not("product_id", "is", null);
+    if (status === "pending") query = query.is("product_id", null);
+
+    if (search?.trim()) {
+      query = query.or(
+        `supplier.ilike.%${search.trim()}%,notes.ilike.%${search.trim()}%,pending_product_name.ilike.%${search.trim()}%`
+      );
+    }
+
+    const from = (page - 1) * limit;
+    const { data, error, count } = await query
+      .order("entry_date", { ascending: false })
+      .order("created_at", { ascending: false })
+      .range(from, from + limit - 1);
+
+    if (error) throw error;
+    return { entries: data ?? [], total: count ?? 0 };
+  },
+
+  // ── Get single entry ──────────────────────────────────────────
+  async getById(storeId, entryId) {
+    const { data, error } = await supabaseAdmin
+      .from("stock_entries")
+      .select(ENTRY_FIELDS)
+      .eq("id", entryId)
+      .eq("store_id", storeId)
+      .single();
+
+    if (error || !data) return null;
+    return data;
+  },
+
+  // ── Create entry ──────────────────────────────────────────────
+  // Accepts either product_id (listed product) or pending_product_name
+  // (not yet listed). The route layer already enforces XOR via Joi,
+  // but we guard again here since service methods should be safe to
+  // call directly (e.g. from other services, scripts, tests).
+  async create(storeId, payload) {
+    const isPending = !payload.product_id;
+
+    if (isPending && !payload.pending_product_name?.trim()) {
+      const err = new Error("pending_product_name is required when product_id is not provided");
+      err.statusCode = 422;
+      err.code = "MISSING_PRODUCT_REFERENCE";
+      throw err;
+    }
+
+    // Validate variant belongs to the given product, if both provided
+    if (payload.product_id && payload.variant_id) {
+      const { data: variant } = await supabaseAdmin
+        .from("product_variants")
+        .select("id, product_id")
+        .eq("id", payload.variant_id)
+        .single();
+
+      if (!variant || variant.product_id !== payload.product_id) {
+        const err = new Error("variant_id does not belong to the given product_id");
+        err.statusCode = 422;
+        err.code = "INVALID_VARIANT";
+        throw err;
+      }
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("stock_entries")
+      .insert({
+        store_id:             storeId,
+        product_id:           payload.product_id           ?? null,
+        pending_product_name: isPending
+                                ? payload.pending_product_name.trim()
+                                : null,
+        variant_id:           payload.variant_id            ?? null,
+        supplier:             payload.supplier?.trim()      ?? null,
+        quantity:             payload.quantity,
+        unit_cost:            payload.unit_cost,
+        total_cost:           payload.total_cost,
+        entry_date:           payload.entry_date,
+        notes:                payload.notes?.trim()         ?? null,
+        is_adjustment:        payload.is_adjustment          ?? false,
+      })
+      .select(ENTRY_FIELDS)
+      .single();
+
+    if (error) throw error;
+
+    // Sync product_variants.stock — only possible for listed products
+    // with a specific variant. Pending entries have no stock to sync yet;
+    // that happens later when the entry is linked via linkPendingEntries.
+    if (!payload.is_adjustment && payload.product_id && payload.variant_id) {
+      await supabaseAdmin.rpc("increment_variant_stock", {
+        p_variant_id: payload.variant_id,
+        p_amount:     payload.quantity,
+      });
+    }
+
+    return data;
+  },
+
+  // ── Update entry ──────────────────────────────────────────────
+  async update(storeId, entryId, payload) {
+    const { data: existing } = await supabaseAdmin
+      .from("stock_entries")
+      .select("id, product_id, pending_product_name, variant_id, quantity, is_adjustment")
+      .eq("id", entryId)
+      .eq("store_id", storeId)
+      .single();
+
+    if (!existing) return null;
+
+    // Determine the resulting state after this partial update is applied,
+    // to enforce the same XOR rule the DB check constraint enforces.
+    const nextProductId = payload.product_id !== undefined
+      ? payload.product_id
+      : existing.product_id;
+    const nextPendingName = payload.pending_product_name !== undefined
+      ? payload.pending_product_name
+      : existing.pending_product_name;
+
+    if (!nextProductId && !nextPendingName?.trim()) {
+      const err = new Error("Entry must have either product_id or pending_product_name");
+      err.statusCode = 422;
+      err.code = "MISSING_PRODUCT_REFERENCE";
+      throw err;
+    }
+    if (nextProductId && nextPendingName) {
+      const err = new Error("Entry cannot have both product_id and pending_product_name — clear one");
+      err.statusCode = 422;
+      err.code = "AMBIGUOUS_PRODUCT_REFERENCE";
+      throw err;
+    }
+
+    // If product_id is being cleared, pending_product_name must be set
+    // and variant_id must be cleared too (matches DB constraint).
+    const update = {};
+    const allowed = [
+      "product_id", "pending_product_name", "supplier",
+      "quantity", "unit_cost", "total_cost",
+      "entry_date", "notes", "is_adjustment", "variant_id",
+    ];
+    for (const key of allowed) {
+      if (payload[key] !== undefined) update[key] = payload[key];
+    }
+
+    // Auto-clear variant_id if product_id is being removed
+    if (payload.product_id === null && update.variant_id === undefined) {
+      update.variant_id = null;
+    }
+    // Auto-clear pending_product_name if product_id is being set
+    if (payload.product_id) {
+      update.pending_product_name = null;
+    }
+
+    update.updated_at = new Date().toISOString();
+
+    const { data, error } = await supabaseAdmin
+      .from("stock_entries")
+      .update(update)
+      .eq("id", entryId)
+      .select(ENTRY_FIELDS)
+      .single();
+
+    if (error) throw error;
+
+    // If this update just linked a pending entry to a real variant for
+    // the first time, sync the stock increment now.
+    const wasPending  = !existing.product_id;
+    const nowLinked   = Boolean(data.product_id && data.variant_id);
+    if (wasPending && nowLinked && !data.is_adjustment) {
+      await supabaseAdmin.rpc("increment_variant_stock", {
+        p_variant_id: data.variant_id,
+        p_amount:     data.quantity,
+      });
+    }
+
+    return data;
+  },
+
+  // ── Delete entry ──────────────────────────────────────────────
+  async delete(storeId, entryId) {
+    const { data: existing } = await supabaseAdmin
+      .from("stock_entries")
+      .select("id")
+      .eq("id", entryId)
+      .eq("store_id", storeId)
+      .single();
+
+    if (!existing) return false;
+
+    const { error } = await supabaseAdmin
+      .from("stock_entries")
+      .delete()
+      .eq("id", entryId);
+
+    if (error) throw error;
+    return true;
+  },
+
+  // ── Link pending entries to a newly-listed product ─────────────
+  // Bulk-updates every stock_entries row matching pending_product_name
+  // for this store, setting product_id (and optionally variant_id),
+  // clearing pending_product_name, and syncing stock for each.
+  //
+  // Typical flow: seller logged 3 purchases of "Air Max 97 (incoming)"
+  // before listing it. Once they create the real product, call this
+  // to retroactively link all 3 entries and credit the stock.
+  async linkPendingEntries(storeId, { pendingProductName, productId, variantId }) {
+    const { data: matches, error: fetchErr } = await supabaseAdmin
+      .from("stock_entries")
+      .select("id, quantity, is_adjustment")
+      .eq("store_id", storeId)
+      .eq("pending_product_name", pendingProductName)
+      .is("product_id", null);
+
+    if (fetchErr) throw fetchErr;
+    if (!matches || matches.length === 0) {
+      return { linked: 0, stockAdded: 0 };
+    }
+
+    // If a variant was given, validate it belongs to the product
+    if (variantId) {
+      const { data: variant } = await supabaseAdmin
+        .from("product_variants")
+        .select("id, product_id")
+        .eq("id", variantId)
+        .single();
+
+      if (!variant || variant.product_id !== productId) {
+        const err = new Error("variant_id does not belong to the given product_id");
+        err.statusCode = 422;
+        err.code = "INVALID_VARIANT";
+        throw err;
+      }
+    }
+
+    const ids = matches.map(m => m.id);
+
+    const { error: updateErr } = await supabaseAdmin
+      .from("stock_entries")
+      .update({
+        product_id:           productId,
+        variant_id:           variantId ?? null,
+        pending_product_name: null,
+        updated_at:           new Date().toISOString(),
+      })
+      .in("id", ids);
+
+    if (updateErr) throw updateErr;
+
+    // Sync stock for the non-adjustment entries, only if a variant was given
+    let stockAdded = 0;
+    if (variantId) {
+      const totalQty = matches
+        .filter(m => !m.is_adjustment)
+        .reduce((sum, m) => sum + m.quantity, 0);
+
+      if (totalQty !== 0) {
+        await supabaseAdmin.rpc("increment_variant_stock", {
+          p_variant_id: variantId,
+          p_amount:     totalQty,
+        });
+        stockAdded = totalQty;
+      }
+    }
+
+    return { linked: ids.length, stockAdded };
+  },
+
+  // ── Summary stats ─────────────────────────────────────────────
+  // Totals for the summary cards at top of the journal page.
+  async getSummary(storeId, { dateFrom, dateTo } = {}) {
+    let query = supabaseAdmin
+      .from("stock_entries")
+      .select("quantity, total_cost, is_adjustment, product_id")
+      .eq("store_id", storeId)
+      .eq("is_adjustment", false);
+
+    if (dateFrom) query = query.gte("entry_date", dateFrom);
+    if (dateTo)   query = query.lte("entry_date", dateTo);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const rows = data ?? [];
+
+    return {
+      totalUnits:    rows.reduce((s, e) => s + e.quantity, 0),
+      totalSpend:    rows.reduce((s, e) => s + Number(e.total_cost), 0),
+      entryCount:    rows.length,
+      // New: surfaces how much is tied up in not-yet-listed products,
+      // useful as a "pending inventory value" indicator.
+      pendingCount:  rows.filter(e => !e.product_id).length,
+      pendingSpend:  rows
+                       .filter(e => !e.product_id)
+                       .reduce((s, e) => s + Number(e.total_cost), 0),
+    };
+  },
+};
+
+export default stockService;

--- a/backend/src/services/storeService.js
+++ b/backend/src/services/storeService.js
@@ -26,7 +26,7 @@ const storeService = {
   async getByOwner(ownerId) {
     const { data, error } = await supabaseAdmin
       .from("stores")
-      .select(STORE_PUBLIC_FIELDS)
+      .select(`${STORE_PUBLIC_FIELDS},config`)
       .eq("owner_id", ownerId)
       .order("created_at", { ascending: false });
 

--- a/frontend/app/dashboard/orders/[id]/page.jsx
+++ b/frontend/app/dashboard/orders/[id]/page.jsx
@@ -17,6 +17,7 @@ import { Badge, Button, Card } from "@/components/ui";
 import { ORDERS, STATUS_CONFIG } from "@/lib/orders-data";
 import { notFound } from "next/navigation";
 import { useOrder } from "@/lib/hooks/useOrders";
+import { Phone } from "lucide-react";
 
 function Section({ title, children }) {
   return (
@@ -32,17 +33,45 @@ function Section({ title, children }) {
   );
 }
 
+function Avatar({ customer }) {
+  return (
+    <div
+      className="w-10 h-10 rounded-full flex items-center justify-center text-[13px] font-semibold flex-shrink-0"
+      style={{ background: customer.avatarBg, color: customer.avatarColor }}
+    >
+      <img src={customer.avatar_url} alt="item" className="rounded-full" />
+    </div>
+  );
+}
+
 export default function OrderDetailPage({ params }) {
   const { id } = use(params);
-  // const [order, setOrder] = useState(null);
-  // const order = ORDERS.find((o) => o.id === id);
-  const {data:order} = useOrder(id);
-  console.log(order)
+  const { data, isLoading, error } = useOrder(id);
 
+  if (isLoading) {
+    return (
+      <div className="space-y-5 animate-pulse">
+        <div
+          className="h-6 w-48 rounded-lg"
+          style={{ background: "var(--color-bg)" }}
+        />
+        <div
+          className="h-32 rounded-2xl"
+          style={{ background: "var(--color-bg)" }}
+        />
+        <div
+          className="h-64 rounded-2xl"
+          style={{ background: "var(--color-bg)" }}
+        />
+      </div>
+    );
+  }
+
+  const order = data?.data ?? data;
   if (!order) notFound();
 
   const cfg = STATUS_CONFIG[order.status] ?? STATUS_CONFIG.Processing;
-  const totalItems = order.items.reduce((s, i) => s + i.qty, 0);
+  const totalItems = order?.order_items.reduce((s, i) => s + i.quantity, 0);
 
   return (
     <div>
@@ -72,7 +101,10 @@ export default function OrderDetailPage({ params }) {
               className="text-[22px] font-semibold tracking-tight"
               style={{ color: "var(--color-text-primary)" }}
             >
-              Order #{order.id}
+              Order #
+              {String(order.id || "")
+                .slice(0, 4)
+                .toUpperCase()}
             </h1>
             <Badge variant={cfg.variant}>{order.status}</Badge>
           </div>
@@ -81,7 +113,7 @@ export default function OrderDetailPage({ params }) {
             style={{ color: "var(--color-text-secondary)" }}
           >
             Placed{" "}
-            {new Date(order.date).toLocaleDateString("en-US", {
+            {new Date(order.created_at).toLocaleDateString("en-US", {
               month: "long",
               day: "numeric",
               year: "numeric",
@@ -130,7 +162,7 @@ export default function OrderDetailPage({ params }) {
               className="divide-y"
               style={{ borderColor: "var(--color-border)" }}
             >
-              {order.items.map((item, i) => (
+              {order?.order_items.map((item, i) => (
                 <div
                   key={item.id + i}
                   className="flex items-center gap-4 px-5 py-4"
@@ -139,14 +171,25 @@ export default function OrderDetailPage({ params }) {
                     className="w-12 h-12 rounded-xl flex items-center justify-center text-2xl flex-shrink-0"
                     style={{ background: "var(--color-bg)" }}
                   >
-                    {item.emoji}
+                    {item.products.thumbnail_url ? (
+                      <img
+                        src={item.products.thumbnail_url}
+                        alt={item.products.name}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-2xl">
+                        📦
+                      </div>
+                    )}
+                    {/* {item.products.thumbnail_url} */}
                   </div>
                   <div className="flex-1 min-w-0">
                     <p
                       className="text-[14px] font-medium"
                       style={{ color: "var(--color-text-primary)" }}
                     >
-                      {item.name}
+                      {item.products.name}
                     </p>
                     <p
                       className="text-[12px]"
@@ -160,13 +203,13 @@ export default function OrderDetailPage({ params }) {
                       className="text-[13px] font-semibold"
                       style={{ color: "var(--color-text-primary)" }}
                     >
-                      ${(item.price * item.qty).toFixed(2)}
+                      K{(item.unit_price * item.quantity).toFixed(2)}
                     </p>
                     <p
                       className="text-[11px]"
                       style={{ color: "var(--color-text-tertiary)" }}
                     >
-                      ${item.price.toFixed(2)} × {item.qty}
+                      K{item.subtotal.toFixed(2)} × {item.quantity}
                     </p>
                   </div>
                 </div>
@@ -181,15 +224,12 @@ export default function OrderDetailPage({ params }) {
               }}
             >
               {[
-                { label: "Subtotal", value: `$${order.subtotal.toFixed(2)}` },
+                { label: "Subtotal", value: `K${order.subtotal.toFixed(2)}` },
                 {
                   label: "Shipping",
-                  value:
-                    order.shipping === 0
-                      ? "Free"
-                      : `$${order.shipping.toFixed(2)}`,
+                  value: order?.shipping === 0 ? "Free" : `K50`,
                 },
-                { label: "Tax", value: `$${order.tax.toFixed(2)}` },
+                { label: "Tax", value: `K${order?.tax?.toFixed(2) || 0.0}` },
               ].map((r) => (
                 <div
                   key={r.label}
@@ -208,7 +248,7 @@ export default function OrderDetailPage({ params }) {
                 }}
               >
                 <span>Total</span>
-                <span>${order.total.toFixed(2)}</span>
+                <span>K{order?.subtotal.toFixed(2)}</span>
               </div>
             </div>
           </Card>
@@ -217,23 +257,23 @@ export default function OrderDetailPage({ params }) {
           <Card>
             <Section title="Order timeline">
               <div className="mt-1">
-                {order.timeline.map((step, i) => {
-                  const isLast = i === order.timeline.length - 1;
+                {order?.history.map((step, i) => {
+                  const isLast = i === order?.history.length - 1;
                   return (
                     <div key={i} className="flex gap-4">
                       <div className="flex flex-col items-center">
                         <div
                           className="w-7 h-7 rounded-full flex items-center justify-center flex-shrink-0 border-2"
                           style={{
-                            background: step.done
+                            background: step.created_at
                               ? "var(--color-accent)"
                               : "white",
-                            borderColor: step.done
+                            borderColor: step.created_at
                               ? "var(--color-accent)"
                               : "var(--color-border-md)",
                           }}
                         >
-                          {step.done ? (
+                          {step.created_at ? (
                             <Check size={12} color="white" strokeWidth={3} />
                           ) : (
                             <Clock
@@ -248,10 +288,10 @@ export default function OrderDetailPage({ params }) {
                             style={{
                               flex: 1,
                               minHeight: 24,
-                              background: step.done
+                              background: step.id
                                 ? "var(--color-accent)"
                                 : "var(--color-border)",
-                              opacity: step.done ? 0.25 : 1,
+                              opacity: step.id ? 0.25 : 1,
                             }}
                           />
                         )}
@@ -260,18 +300,26 @@ export default function OrderDetailPage({ params }) {
                         <p
                           className="text-[14px] font-medium"
                           style={{
-                            color: step.done
+                            color: step.id
                               ? "var(--color-text-primary)"
                               : "var(--color-text-tertiary)",
                           }}
                         >
-                          {step.event}
+                          {step.status}
                         </p>
                         <p
                           className="text-[12px]"
                           style={{ color: "var(--color-text-tertiary)" }}
                         >
-                          {step.date}
+                          {new Date(step.created_at).toLocaleDateString(
+                            "en-US",
+                            {
+                              month: "long",
+                              day: "numeric",
+                              year: "numeric",
+                            }
+                          )}
+                          {/* {step.created_at} */}
                         </p>
                       </div>
                     </div>
@@ -309,14 +357,14 @@ export default function OrderDetailPage({ params }) {
                     color: order.customer.avatarColor,
                   }}
                 >
-                  {order.customer.avatar}
+                  <Avatar customer={order.customer} />
                 </div>
                 <div className="flex-1 min-w-0">
                   <p
                     className="text-[14px] font-semibold truncate"
                     style={{ color: "var(--color-text-primary)" }}
                   >
-                    {order.customer.name}
+                    {order.customer.full_name}
                   </p>
                   <p
                     className="text-[12px] truncate"
@@ -340,40 +388,66 @@ export default function OrderDetailPage({ params }) {
 
           {/* Shipping */}
           <Card>
-            <Section title="Shipping address">
-              <div className="flex items-start gap-2.5 mt-1">
-                <MapPin
-                  size={14}
-                  className="mt-0.5 flex-shrink-0"
-                  style={{ color: "var(--color-text-tertiary)" }}
-                />
-                <div>
-                  <p
-                    className="text-[13px] font-medium"
-                    style={{ color: "var(--color-text-primary)" }}
-                  >
-                    {order.shippingAddress.line1}
-                  </p>
-                  <p
-                    className="text-[12px]"
-                    style={{ color: "var(--color-text-secondary)" }}
-                  >
-                    {order.shippingAddress.city}, {order.shippingAddress.state}{" "}
-                    {order.shippingAddress.zip}
-                  </p>
-                  <p
-                    className="text-[12px]"
-                    style={{ color: "var(--color-text-secondary)" }}
-                  >
-                    {order.shippingAddress.country}
-                  </p>
+            {order.shipping_info.city ? (
+              <Section title="Shipping address">
+                <div className="flex items-start gap-2.5 mt-1">
+                  <MapPin
+                    size={14}
+                    className="mt-0.5 flex-shrink-0"
+                    style={{ color: "var(--color-text-tertiary)" }}
+                  />
+                  <div>
+                    <p
+                      className="text-[13px] font-medium"
+                      style={{ color: "var(--color-text-primary)" }}
+                    >
+                      {order.shipping_info.line1}
+                    </p>
+                    <p
+                      className="text-[12px]"
+                      style={{ color: "var(--color-text-secondary)" }}
+                    >
+                      {order.shipping_info.city}, {order.shipping_info.state}{" "}
+                      {order.shipping_info.zip}
+                    </p>
+                    <p
+                      className="text-[12px]"
+                      style={{ color: "var(--color-text-secondary)" }}
+                    >
+                      {order.shipping_info.country}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            </Section>
+              </Section>
+            ) : (
+              <Section title="Contact Info">
+                <div className="flex items-start gap-2.5 mt-1">
+                  <Phone
+                    size={14}
+                    className="mt-0.5 flex-shrink-0"
+                    style={{ color: "var(--color-text-tertiary)" }}
+                  />
+                  <div>
+                    <p
+                      className="text-[13px] font-medium"
+                      style={{ color: "var(--color-text-primary)" }}
+                    >
+                      {order.shipping_info.phone}
+                    </p>
+                    <p
+                      className="text-[14px]"
+                      style={{ color: "var(--color-text-secondary)" }}
+                    >
+                      {order.shipping_info.name}
+                    </p>
+                  </div>
+                </div>
+              </Section>
+            )}
           </Card>
 
           {/* Payment */}
-          <Card>
+          {/* <Card>
             <Section title="Payment">
               <div className="flex items-center gap-2.5 mt-1">
                 <CreditCard
@@ -395,7 +469,7 @@ export default function OrderDetailPage({ params }) {
                 </Badge>
               </div>
             </Section>
-          </Card>
+          </Card> */}
 
           {/* Danger zone */}
           {order.status !== "Cancelled" && (

--- a/frontend/app/dashboard/stock/StockEntryForm.jsx
+++ b/frontend/app/dashboard/stock/StockEntryForm.jsx
@@ -1,0 +1,483 @@
+"use client";
+// app/stock/StockEntryForm.jsx
+import { useState, useEffect, useCallback } from "react";
+import { X, Calculator, Package } from "lucide-react";
+import { useProducts } from "@/lib/hooks/useProducts";
+import { useVariants } from "@/lib/hooks/useProducts";
+import useAuthStore from "@/lib/store/useAuthStore";
+import { cn } from "@/lib/utils";
+
+// ── Tiny shared input primitives ──────────────────────────────
+const inputCls =
+  "w-full h-10 px-3 rounded-xl border text-[13px] outline-none transition-all focus:border-[var(--color-accent)] focus:ring-2 focus:ring-[var(--color-accent)]/10";
+const inputStyle = {
+  borderColor: "var(--color-border-md)",
+  color: "var(--color-text-primary)",
+  background: "white",
+};
+
+function Field({ label, error, required, children, hint }) {
+  return (
+    <div className="space-y-1.5">
+      <label
+        className="block text-[12px] font-semibold"
+        style={{ color: "var(--color-text-secondary)" }}
+      >
+        {label}
+        {required && (
+          <span className="text-[var(--color-danger)] ml-0.5">*</span>
+        )}
+      </label>
+      {children}
+      {hint && !error && (
+        <p className="text-[11px]" style={{ color: "var(--color-text-muted)" }}>
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p className="text-[11px]" style={{ color: "var(--color-danger)" }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Form ──────────────────────────────────────────────────────
+function EntryForm({ initial, onSubmit, onCancel, loading, fieldErrors }) {
+  const today = new Date().toISOString().split("T")[0];
+
+  const [form, setForm] = useState({
+    product_name: initial?.pending_product_name ?? "",
+    product_id: initial?.product_id ?? "",
+    variant_id: initial?.variant_id ?? "",
+    supplier: initial?.supplier ?? "",
+    quantity: initial?.quantity ?? "",
+    unit_cost: initial?.unit_cost ?? "",
+    total_cost: initial?.total_cost ?? "",
+    entry_date: initial?.entry_date ?? today,
+    notes: initial?.notes ?? "",
+    is_adjustment: initial?.is_adjustment ?? false,
+  });
+  const [errors, setErrors] = useState({});
+  const [isNew, setIsNew] = useState(Boolean(initial?.product_id));
+
+  // Merge server-side field errors in
+  useEffect(() => {
+    if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+      setErrors((prev) => ({ ...prev, ...fieldErrors }));
+    }
+  }, [fieldErrors]);
+
+  const set = (field, val) => {
+    setErrors((prev) => ({ ...prev, [field]: undefined }));
+    setForm((prev) => {
+      const next = { ...prev, [field]: val };
+      // Auto-compute total_cost when qty or unit_cost changes
+      if (field === "quantity" || field === "unit_cost") {
+        const qty = Number(field === "quantity" ? val : next.quantity);
+        const cost = Number(field === "unit_cost" ? val : next.unit_cost);
+        if (qty > 0 && cost >= 0) {
+          next.total_cost = (qty * cost).toFixed(2);
+        }
+      }
+      return next;
+    });
+  };
+
+  // Load products for the selector
+  const { data: productsData } = useProducts({
+    page: 1,
+    limit: 20,
+    status: "all",
+    category: undefined,
+    search: undefined,
+  });
+  const products = productsData ?? [];
+
+  // Load variants when a product is selected
+  const { data: variantsData } = useVariants(form.product_id || null);
+  const variants = variantsData?.data ?? [];
+
+  // Reset variant when product changes
+  useEffect(() => {
+    set("variant_id", "");
+  }, [form.product_id]);
+
+  const switchProduct = () => {
+    setIsNew(!isNew);
+  };
+
+  const validate = () => {
+    const e = {};
+    if (!form.product_name && !form.product_id ) e.product_name = "Enter a product";
+    if (!form.product_id && !form.product_name) e.product_id = "Select a product";
+    if (!form.quantity) e.quantity = "Quantity is required";
+    if (Number(form.quantity) === 0) e.quantity = "Quantity cannot be zero";
+    if (form.unit_cost === "") e.unit_cost = "Unit cost is required";
+    if (form.total_cost === "") e.total_cost = "Total cost is required";
+    if (!form.entry_date) e.entry_date = "Date is required";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!validate()) return;
+    onSubmit({
+      pending_product_name: form.product_name,
+      product_id: form.product_id || null,
+      variant_id: form.variant_id || null,
+      supplier: form.supplier || null,
+      quantity: Number(form.quantity),
+      unit_cost: Number(form.unit_cost),
+      total_cost: Number(form.total_cost),
+      entry_date: form.entry_date,
+      notes: form.notes || null,
+      is_adjustment: form.is_adjustment,
+    });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col h-full overflow-y-scroll"
+    >
+      <div className="flex-1 overflow-y-auto p-5 space-y-5">
+        {/* Adjustment toggle */}
+        {/* <div
+          className="flex items-center gap-3 p-3 rounded-xl border"
+          style={{ borderColor: "var(--color-border)", background: "var(--color-bg)" }}
+        >
+          <div className="flex-1">
+            <p className="text-[13px] font-semibold" style={{ color: "var(--color-text-primary)" }}>
+              Stock adjustment
+            </p>
+            <p className="text-[11px]" style={{ color: "var(--color-text-muted)" }}>
+              Log a correction (e.g. stock count fix, return) instead of a purchase
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => set("is_adjustment", !form.is_adjustment)}
+            className="relative flex-shrink-0 rounded-full transition-colors duration-200"
+            style={{ width: 36, height: 20, background: form.is_adjustment ? "var(--color-warning)" : "var(--color-border-md)" }}
+          >
+            <span
+              className="absolute top-[3px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform duration-200"
+              style={{ transform: form.is_adjustment ? "translateX(19px)" : "translateX(3px)" }}
+            />
+          </button>
+        </div> */}
+
+        {/* Product */}
+        <Field label="Product" required error={errors.product_id || errors.product_name}>
+          {!initial && <div className="flex gap-4">
+            <label
+              htmlFor="New Product"
+              className="block text-[11px] font-semibold"
+              style={{ color: "var(--color-text-secondary)" }}
+            >
+              New
+            </label>
+            <input
+              type="radio"
+              name="New product"
+              id="newprod"
+              value={!isNew}
+              checked={!isNew}
+              onChange={switchProduct}
+            />
+            <label
+              htmlFor="Existing Product"
+              className="block text-[11px] font-semibold"
+              style={{ color: "var(--color-text-secondary)" }}
+            >
+              Existing
+            </label>
+            <input
+              type="radio"
+              name="Existing product"
+              id="exprod"
+              value={isNew}
+              checked={isNew}
+              onChange={switchProduct}
+            />
+          </div>}
+          {!isNew ? (
+            <input
+              value={form.product_name}
+              onChange={(e) => set("product_name", e.target.value)}
+              placeholder="New product's name…"
+              className={inputCls}
+              style={inputStyle}
+            />
+          ) : (
+            <select
+              value={form.product_id}
+              onChange={(e) => set("product_id", e.target.value)}
+              className={`${inputCls} cursor-pointer`}
+              style={{
+                ...inputStyle,
+                borderColor: errors.product_id
+                  ? "var(--color-danger)"
+                  : "var(--color-border-md)",
+              }}
+            >
+              <option value="">Select a product…</option>
+              {products.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </Field>
+
+        {/* Variant (only if product has multiple variants) */}
+        {form.product_id && variants.length > 1 && (
+          <Field label="Variant">
+            <select
+              value={form.variant_id}
+              onChange={(e) => set("variant_id", e.target.value)}
+              className={`${inputCls} cursor-pointer`}
+              style={inputStyle}
+            >
+              <option value="">All variants / Default</option>
+              {variants.map((v) => (
+                <option key={v.id} value={v.id}>
+                  {v.name}
+                  {v.sku ? ` — ${v.sku}` : ""}
+                </option>
+              ))}
+            </select>
+          </Field>
+        )}
+
+        {/* Supplier */}
+        <Field label="Supplier" hint="Where you bought the stock from">
+          <input
+            value={form.supplier}
+            onChange={(e) => set("supplier", e.target.value)}
+            placeholder="e.g. Wholesale Market, Ali Express…"
+            className={inputCls}
+            style={inputStyle}
+          />
+        </Field>
+
+        {/* Date */}
+        <Field label="Date of purchase" required error={errors.entry_date}>
+          <input
+            type="date"
+            value={form.entry_date}
+            max={today}
+            onChange={(e) => set("entry_date", e.target.value)}
+            className={inputCls}
+            style={{
+              ...inputStyle,
+              borderColor: errors.entry_date
+                ? "var(--color-danger)"
+                : "var(--color-border-md)",
+            }}
+          />
+        </Field>
+
+        {/* Quantity + Unit cost */}
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Units" required error={errors.quantity}>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={form.quantity}
+              onChange={(e) => set("quantity", e.target.value)}
+              placeholder="0"
+              className={inputCls}
+              style={{
+                ...inputStyle,
+                borderColor: errors.quantity
+                  ? "var(--color-danger)"
+                  : "var(--color-border-md)",
+              }}
+            />
+          </Field>
+          <Field label="Unit cost (ZMW)" required error={errors.unit_cost}>
+            <div className="relative">
+              <span
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-[12px] font-semibold"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                K
+              </span>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.unit_cost}
+                onChange={(e) => set("unit_cost", e.target.value)}
+                placeholder="0.00"
+                className={`${inputCls} pl-7`}
+                style={{
+                  ...inputStyle,
+                  borderColor: errors.unit_cost
+                    ? "var(--color-danger)"
+                    : "var(--color-border-md)",
+                }}
+              />
+            </div>
+          </Field>
+        </div>
+
+        {/* Total cost (auto-computed, but editable for discounts) */}
+        <Field
+          label="Total cost (ZMW)"
+          required
+          error={errors.total_cost}
+          hint="Auto-calculated from units × unit cost. Edit if you got a bulk discount."
+        >
+          <div className="relative">
+            <span
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-[12px] font-semibold"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              K
+            </span>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={form.total_cost}
+              onChange={(e) => set("total_cost", e.target.value)}
+              placeholder="0.00"
+              className={`${inputCls} pl-7`}
+              style={{
+                ...inputStyle,
+                borderColor: errors.total_cost
+                  ? "var(--color-danger)"
+                  : "var(--color-border-md)",
+              }}
+            />
+            {/* Recalc button */}
+            {form.quantity && form.unit_cost && (
+              <button
+                type="button"
+                onClick={() =>
+                  set(
+                    "total_cost",
+                    (Number(form.quantity) * Number(form.unit_cost)).toFixed(2)
+                  )
+                }
+                title="Recalculate"
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 rounded-lg hover:bg-[var(--color-bg)] transition-colors"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                <Calculator size={13} />
+              </button>
+            )}
+          </div>
+        </Field>
+
+        {/* Notes */}
+        <Field label="Notes">
+          <textarea
+            value={form.notes}
+            onChange={(e) => set("notes", e.target.value)}
+            placeholder="Batch number, invoice ref, condition…"
+            rows={3}
+            className={`${inputCls} h-auto resize-none py-2.5`}
+            style={inputStyle}
+          />
+        </Field>
+      </div>
+
+      {/* Footer actions */}
+      <div
+        className="flex items-center gap-2 p-4 border-t flex-shrink-0"
+        style={{ borderColor: "var(--color-border)", background: "white" }}
+      >
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 h-10 rounded-xl border text-[13px] font-semibold transition-colors hover:bg-[var(--color-bg)]"
+          style={{
+            borderColor: "var(--color-border-md)",
+            color: "var(--color-text-secondary)",
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="flex-1 h-10 rounded-xl text-[13px] font-bold text-white transition-all disabled:opacity-50"
+          style={{ background: "var(--color-accent)" }}
+        >
+          {loading ? "Saving…" : initial ? "Save changes" : "Log entry"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Drawer wrapper ────────────────────────────────────────────
+export function StockEntryDrawer({
+  open,
+  entry,
+  onClose,
+  onSave,
+  loading,
+  fieldErrors,
+}) {
+  if (!open) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/30 backdrop-blur-sm z-40"
+        onClick={onClose}
+      />
+      {/* Drawer */}
+      <div
+        className="fixed right-0 top-0 bottom-0 z-50 flex flex-col bg-white shadow-2xl"
+        style={{ width: "min(100vw, 440px)" }}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-5 py-4 border-b flex-shrink-0"
+          style={{ borderColor: "var(--color-border)" }}
+        >
+          <div className="flex items-center gap-2.5">
+            <div
+              className="w-8 h-8 rounded-xl flex items-center justify-center"
+              style={{ background: "var(--color-accent-subtle)" }}
+            >
+              <Package size={16} style={{ color: "var(--color-accent)" }} />
+            </div>
+            <p
+              className="text-[15px] font-bold"
+              style={{ color: "var(--color-text-primary)" }}
+            >
+              {entry ? "Edit entry" : "Log stock purchase"}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-xl hover:bg-[var(--color-bg)] transition-colors"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <EntryForm
+          initial={entry}
+          onSubmit={onSave}
+          onCancel={onClose}
+          loading={loading}
+          fieldErrors={fieldErrors}
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/dashboard/stock/StockTable.jsx
+++ b/frontend/app/dashboard/stock/StockTable.jsx
@@ -1,0 +1,387 @@
+"use client";
+// app/stock/StockTable.jsx
+
+import { useState } from "react";
+import {
+  Search, Filter, Trash2, Pencil, ChevronLeft, ChevronRight,
+  Package, AlertTriangle, ArrowUpDown, ArrowDown, ArrowUp,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function formatCurrency(val) {
+  return `K${Number(val ?? 0).toLocaleString("en-ZM", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function formatDate(iso) {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+}
+
+// ── Filter bar ─────────────────────────────────────────────────
+function FilterBar({ filters, onChange }) {
+  const [open, setOpen] = useState(false);
+
+  const hasActive = filters.search || filters.dateFrom || filters.dateTo || filters.includeAdjustments;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {/* Search */}
+      <div className="relative flex-1 min-w-[200px]">
+        <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none"
+          style={{ color: "var(--color-text-muted)" }} />
+        <input
+          value={filters.search}
+          onChange={e => onChange({ ...filters, search: e.target.value, page: 1 })}
+          placeholder="Search supplier or notes…"
+          className="w-full h-9 pl-8 pr-3 rounded-xl border text-[12px] outline-none focus:border-[var(--color-accent)] transition-colors"
+          style={{ borderColor: "var(--color-border-md)", color: "var(--color-text-primary)", background: "white" }}
+        />
+      </div>
+
+      {/* Date range */}
+      <input
+        type="date"
+        value={filters.dateFrom}
+        onChange={e => onChange({ ...filters, dateFrom: e.target.value, page: 1 })}
+        className="h-9 px-2.5 rounded-xl border text-[12px] outline-none focus:border-[var(--color-accent)] transition-colors"
+        style={{ borderColor: "var(--color-border-md)", color: "var(--color-text-primary)", background: "white" }}
+      />
+      <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>to</span>
+      <input
+        type="date"
+        value={filters.dateTo}
+        onChange={e => onChange({ ...filters, dateTo: e.target.value, page: 1 })}
+        className="h-9 px-2.5 rounded-xl border text-[12px] outline-none focus:border-[var(--color-accent)] transition-colors"
+        style={{ borderColor: "var(--color-border-md)", color: "var(--color-text-primary)", background: "white" }}
+      />
+
+      {/* Adjustments toggle */}
+      <label className="flex items-center gap-2 h-9 px-3 rounded-xl border cursor-pointer text-[12px] font-medium select-none"
+        style={{ borderColor: "var(--color-border-md)", color: "var(--color-text-secondary)", background: "white" }}>
+        <input
+          type="checkbox"
+          checked={filters.includeAdjustments}
+          onChange={e => onChange({ ...filters, includeAdjustments: e.target.checked, page: 1 })}
+          className="w-3.5 h-3.5 accent-[var(--color-accent)]"
+        />
+        Show adjustments
+      </label>
+
+      {/* Clear */}
+      {hasActive && (
+        <button
+          onClick={() => onChange({ search: "", dateFrom: "", dateTo: "", includeAdjustments: false, page: 1 })}
+          className="h-9 px-3 rounded-xl text-[12px] font-medium transition-colors hover:bg-[var(--color-danger-bg)]"
+          style={{ color: "var(--color-danger)", border: "1px solid var(--color-danger)" }}
+        >
+          Clear filters
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Delete confirmation ───────────────────────────────────────
+function DeleteConfirm({ entry, onConfirm, onCancel, loading }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-sm" onClick={onCancel} />
+      <div className="relative bg-white rounded-3xl p-6 max-w-sm w-full shadow-2xl"
+        style={{ border: "1px solid var(--color-border)" }}>
+        <div className="w-12 h-12 rounded-2xl flex items-center justify-center mb-4"
+          style={{ background: "var(--color-danger-bg)" }}>
+          <AlertTriangle size={22} style={{ color: "var(--color-danger)" }} />
+        </div>
+        <h3 className="text-[16px] font-bold mb-1.5" style={{ color: "var(--color-text-primary)" }}>
+          Delete this entry?
+        </h3>
+        <p className="text-[13px] mb-1" style={{ color: "var(--color-text-secondary)" }}>
+          <strong>{entry?.product?.name}</strong>
+          {entry?.variant?.name && ` — ${entry.variant.name}`}
+        </p>
+        <p className="text-[12px] mb-5" style={{ color: "var(--color-text-muted)" }}>
+          {formatDate(entry?.entry_date)} · {entry?.quantity} units · {formatCurrency(entry?.total_cost)}
+        </p>
+        <p className="text-[12px] mb-5" style={{ color: "var(--color-text-secondary)" }}>
+          This cannot be undone. The entry will be permanently removed from your journal.
+        </p>
+        <div className="flex gap-2">
+          <button onClick={onCancel}
+            className="flex-1 h-10 rounded-xl border text-[13px] font-semibold hover:bg-[var(--color-bg)] transition-colors"
+            style={{ borderColor: "var(--color-border-md)", color: "var(--color-text-secondary)" }}>
+            Cancel
+          </button>
+          <button onClick={onConfirm} disabled={loading}
+            className="flex-1 h-10 rounded-xl text-[13px] font-bold text-white disabled:opacity-50 transition-colors"
+            style={{ background: "var(--color-danger)" }}>
+            {loading ? "Deleting…" : "Delete entry"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Column header with sort ────────────────────────────────────
+function ColHeader({ label, field, sort, onSort, className }) {
+  const active = sort?.field === field;
+  return (
+    <th className={cn("text-left py-3 px-4 cursor-pointer select-none group", className)}
+      onClick={() => onSort?.(field)}>
+      <div className="flex items-center gap-1.5">
+        <span className="text-[11px] font-semibold uppercase tracking-wider"
+          style={{ color: active ? "var(--color-accent)" : "var(--color-text-muted)" }}>
+          {label}
+        </span>
+        {active
+          ? sort.dir === "asc"
+            ? <ArrowUp size={11} style={{ color: "var(--color-accent)" }} />
+            : <ArrowDown size={11} style={{ color: "var(--color-accent)" }} />
+          : <ArrowUpDown size={11} className="opacity-0 group-hover:opacity-40 transition-opacity"
+              style={{ color: "var(--color-text-muted)" }} />
+        }
+      </div>
+    </th>
+  );
+}
+
+// ── Main table ─────────────────────────────────────────────────
+export function StockTable({
+  entries,
+  total,
+  isLoading,
+  isRefreshing,
+  filters,
+  onFilterChange,
+  onEdit,
+  onDelete,
+  deleteLoading,
+  page,
+  limit,
+  onPageChange,
+}) {
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [sort, setSort] = useState({ field: "entry_date", dir: "desc" });
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+
+  const handleSort = (field) => {
+    setSort(prev =>
+      prev.field === field
+        ? { field, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { field, dir: "desc" }
+    );
+  };
+
+  // Client-side sort on top of server-sorted data
+  const sorted = [...(entries ?? [])].sort((a, b) => {
+    let av = a[sort.field], bv = b[sort.field];
+    if (sort.field === "product") { av = a.product?.name; bv = b.product?.name; }
+    if (typeof av === "string") return sort.dir === "asc" ? av.localeCompare(bv ?? "") : (bv ?? "").localeCompare(av);
+    return sort.dir === "asc" ? (av ?? 0) - (bv ?? 0) : (bv ?? 0) - (av ?? 0);
+  });
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    await onDelete(deleteTarget.id);
+    setDeleteTarget(null);
+  };
+
+  return (
+    <div>
+      {/* Filter bar */}
+      <div className="mb-4">
+        <FilterBar filters={filters} onChange={onFilterChange} />
+      </div>
+
+      {/* Table card */}
+      <div className="bg-white rounded-2xl border overflow-hidden"
+        style={{ borderColor: "var(--color-border)", opacity: isRefreshing ? 0.7 : 1, transition: "opacity 0.2s" }}>
+
+        {isLoading ? (
+          <div className="py-16 flex flex-col items-center gap-3">
+            <div className="w-8 h-8 border-2 rounded-full animate-spin"
+              style={{ borderColor: "var(--color-border-md)", borderTopColor: "var(--color-accent)" }} />
+            <p className="text-[13px]" style={{ color: "var(--color-text-muted)" }}>Loading entries…</p>
+          </div>
+        ) : sorted.length === 0 ? (
+          <div className="py-16 flex flex-col items-center gap-3">
+            <div className="w-14 h-14 rounded-2xl flex items-center justify-center"
+              style={{ background: "var(--color-bg)" }}>
+              <Package size={26} style={{ color: "var(--color-text-muted)" }} />
+            </div>
+            <p className="text-[14px] font-semibold" style={{ color: "var(--color-text-primary)" }}>
+              No entries found
+            </p>
+            <p className="text-[13px]" style={{ color: "var(--color-text-secondary)" }}>
+              {filters.search || filters.dateFrom || filters.dateTo
+                ? "Try adjusting your filters"
+                : "Start by logging your first stock purchase"}
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead style={{ background: "var(--color-bg)", borderBottom: "1px solid var(--color-border)" }}>
+                <tr>
+                  <ColHeader label="Date"       field="entry_date"   sort={sort} onSort={handleSort} />
+                  <ColHeader label="Product"    field="product"      sort={sort} onSort={handleSort} />
+                  <ColHeader label="Supplier"   field="supplier"     sort={sort} onSort={handleSort} className="hidden md:table-cell" />
+                  <ColHeader label="Units"      field="quantity"     sort={sort} onSort={handleSort} />
+                  <ColHeader label="Unit cost"  field="unit_cost"    sort={sort} onSort={handleSort} className="hidden sm:table-cell" />
+                  <ColHeader label="Total"      field="total_cost"   sort={sort} onSort={handleSort} />
+                  <th className="py-3 px-4" />
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((entry, i) => (
+                  <tr key={entry.id}
+                    className="group border-t hover:bg-[var(--color-bg)] transition-colors"
+                    style={{ borderColor: "var(--color-border)" }}>
+
+                    {/* Date */}
+                    <td className="py-3.5 px-4">
+                      <div>
+                        <p className="text-[12px] font-medium" style={{ color: "var(--color-text-primary)" }}>
+                          {formatDate(entry.entry_date)}
+                        </p>
+                        {entry.is_adjustment && (
+                          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-md"
+                            style={{ background: "var(--color-warning-bg)", color: "var(--color-warning)" }}>
+                            Adjustment
+                          </span>
+                        )}
+                      </div>
+                    </td>
+
+                    {/* Product */}
+                    <td className="py-3.5 px-4">
+                      <div className="flex items-center gap-2.5">
+                        <div className="w-8 h-8 rounded-lg overflow-hidden flex-shrink-0"
+                          style={{ background: "var(--color-bg)" }}>
+                          {entry.product?.thumbnail_url
+                            ? <img src={entry.product.thumbnail_url} alt="" className="w-full h-full object-cover" />
+                            : <Package size={14} className="m-auto mt-1.5" style={{ color: "var(--color-text-muted)" }} />
+                          }
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-[13px] font-semibold truncate max-w-[160px]"
+                            style={{ color: "var(--color-text-primary)" }}>
+                            {entry.product?.name ?? entry?.pending_product_name}
+                          </p>
+                          {entry.variant?.name && (
+                            <p className="text-[11px]" style={{ color: "var(--color-text-muted)" }}>
+                              {entry.variant.name}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+
+                    {/* Supplier */}
+                    <td className="py-3.5 px-4 hidden md:table-cell">
+                      <p className="text-[12px]" style={{ color: "var(--color-text-secondary)" }}>
+                        {entry.supplier ?? <span style={{ color: "var(--color-text-muted)" }}>—</span>}
+                      </p>
+                    </td>
+
+                    {/* Units */}
+                    <td className="py-3.5 px-4">
+                      <p className="text-[13px] font-semibold tabular-nums"
+                        style={{ color: entry.quantity < 0 ? "var(--color-danger)" : "var(--color-text-primary)" }}>
+                        {entry.quantity > 0 ? "+" : ""}{entry.quantity}
+                      </p>
+                    </td>
+
+                    {/* Unit cost */}
+                    <td className="py-3.5 px-4 hidden sm:table-cell">
+                      <p className="text-[12px] tabular-nums" style={{ color: "var(--color-text-secondary)" }}>
+                        {formatCurrency(entry.unit_cost)}
+                      </p>
+                    </td>
+
+                    {/* Total */}
+                    <td className="py-3.5 px-4">
+                      <p className="text-[13px] font-bold tabular-nums"
+                        style={{ color: "var(--color-accent)" }}>
+                        {formatCurrency(entry.total_cost)}
+                      </p>
+                      {entry.notes && (
+                        <p className="text-[10px] mt-0.5 truncate max-w-[120px]"
+                          style={{ color: "var(--color-text-muted)" }}>
+                          {entry.notes}
+                        </p>
+                      )}
+                    </td>
+
+                    {/* Actions */}
+                    <td className="py-3.5 px-3">
+                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <button
+                          onClick={() => onEdit(entry)}
+                          className="w-7 h-7 flex items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-accent-subtle)]"
+                          style={{ color: "var(--color-text-secondary)" }}
+                          title="Edit entry"
+                        >
+                          <Pencil size={13} />
+                        </button>
+                        <button
+                          onClick={() => setDeleteTarget(entry)}
+                          className="w-7 h-7 flex items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-danger-bg)]"
+                          style={{ color: "var(--color-text-secondary)" }}
+                          title="Delete entry"
+                        >
+                          <Trash2 size={13} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between px-4 py-3 border-t"
+            style={{ borderColor: "var(--color-border)", background: "var(--color-bg)" }}>
+            <p className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>
+              {total.toLocaleString()} entr{total !== 1 ? "ies" : "y"} · Page {page} of {totalPages}
+            </p>
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => onPageChange(page - 1)}
+                disabled={page === 1}
+                className="w-8 h-8 flex items-center justify-center rounded-xl border transition-colors hover:bg-white disabled:opacity-40"
+                style={{ borderColor: "var(--color-border-md)", color: "var(--color-text-secondary)" }}
+              >
+                <ChevronLeft size={14} />
+              </button>
+              <button
+                onClick={() => onPageChange(page + 1)}
+                disabled={page >= totalPages}
+                className="w-8 h-8 flex items-center justify-center rounded-xl border transition-colors hover:bg-white disabled:opacity-40"
+                style={{ borderColor: "var(--color-border-md)", color: "var(--color-text-secondary)" }}
+              >
+                <ChevronRight size={14} />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Delete confirm modal */}
+      {deleteTarget && (
+        <DeleteConfirm
+          entry={deleteTarget}
+          onConfirm={confirmDelete}
+          onCancel={() => setDeleteTarget(null)}
+          loading={deleteLoading}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/dashboard/stock/layout.jsx
+++ b/frontend/app/dashboard/stock/layout.jsx
@@ -1,0 +1,228 @@
+"use client";
+// app/stock/layout.jsx
+// ─────────────────────────────────────────────────────────────
+// Wraps every page under /stock with the PIN lock.
+// The lock resets every time the user navigates to this route.
+// ─────────────────────────────────────────────────────────────
+
+import { useState, useEffect } from "react";
+import { usePathname }         from "next/navigation";
+import { Lock, KeyRound, Eye, EyeOff, ShieldCheck, AlertCircle, Loader2 } from "lucide-react";
+import { useStockLock }        from "@/lib/hooks/useStockLock";
+import { cn }                  from "@/lib/utils";
+
+// ── PIN input — single digit boxes ────────────────────────────
+function PinInput({ value, onChange, onSubmit, label, error, autoFocus }) {
+  const digits = 4;
+  const chars  = value.split("");
+
+  const handleKey = (e) => {
+    if (e.key === "Enter") { onSubmit?.(); return; }
+    if (e.key === "Backspace") { onChange(value.slice(0, -1)); return; }
+    if (/^\d$/.test(e.key) && value.length < digits) { onChange(value + e.key); }
+  };
+
+  return (
+    <div className="space-y-3">
+      {label && (
+        <p className="text-[12px] font-semibold text-center"
+          style={{ color: "var(--color-text-secondary)" }}>
+          {label}
+        </p>
+      )}
+      <div
+        className="flex gap-3 justify-center"
+        tabIndex={0}
+        onKeyDown={handleKey}
+        autoFocus={autoFocus}
+        onClick={e => e.currentTarget.focus()}
+        style={{ outline: "none" }}
+      >
+        {Array.from({ length: digits }).map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "w-12 h-14 rounded-2xl border-2 flex items-center justify-center text-[22px] font-bold transition-all",
+              i === chars.length
+                ? "border-[var(--color-accent)] shadow-[0_0_0_4px_rgba(0,87,255,0.12)]"
+                : chars[i] ? "border-[var(--color-border-md)]" : "border-[var(--color-border)]"
+            )}
+            style={{
+              background:  chars[i] ? "var(--color-accent-subtle)" : "white",
+              color:       "var(--color-text-primary)",
+            }}
+          >
+            {chars[i] ? "●" : ""}
+          </div>
+        ))}
+      </div>
+      {error && (
+        <div className="flex items-center justify-center gap-1.5 text-[12px]"
+          style={{ color: "var(--color-danger)" }}>
+          <AlertCircle size={12} />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Lock screen ────────────────────────────────────────────────
+function LockScreen({ onUnlock, error, loading, clearError }) {
+  const [pin, setPin] = useState("");
+
+  const handleSubmit = async () => {
+    if (pin.length < 4) return;
+    const ok = await onUnlock(pin);
+    if (!ok) setPin("");
+  };
+
+  // Auto-submit when 4 digits entered
+  useEffect(() => {
+    if (pin.length === 4) handleSubmit();
+  }, [pin]);
+
+  return (
+    <div className="min-h-[calc(100vh-120px)] flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="w-16 h-16 rounded-3xl flex items-center justify-center mx-auto mb-5"
+            style={{ background: "var(--color-accent-subtle)" }}>
+            <Lock size={28} style={{ color: "var(--color-accent)" }} />
+          </div>
+          <h2 className="text-[20px] font-bold mb-1.5"
+            style={{ color: "var(--color-text-primary)" }}>
+            Stock journal is locked
+          </h2>
+          <p className="text-[13px]" style={{ color: "var(--color-text-secondary)" }}>
+            Enter your PIN to access purchase records
+          </p>
+        </div>
+
+        <div className="bg-white rounded-3xl border p-6 space-y-5 shadow-sm"
+          style={{ borderColor: "var(--color-border)" }}>
+          <PinInput
+            value={pin}
+            onChange={(v) => { setPin(v); clearError(); }}
+            onSubmit={handleSubmit}
+            label="Enter PIN"
+            error={error}
+            autoFocus
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={pin.length < 4 || loading}
+            className="w-full h-11 rounded-xl text-[14px] font-bold text-white flex items-center justify-center gap-2 transition-all disabled:opacity-40 hover:opacity-90"
+            style={{ background: "var(--color-accent)" }}>
+            {loading
+              ? <><Loader2 size={15} className="animate-spin" /> Checking…</>
+              : <><KeyRound size={15} /> Unlock</>
+            }
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Setup screen ───────────────────────────────────────────────
+function SetupScreen({ onSetPin, error, loading, clearError }) {
+  const [pin,     setPin]     = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [step,    setStep]    = useState(1); // 1 = choose pin, 2 = confirm
+
+  const handleStep1 = () => { if (pin.length === 4) setStep(2); };
+  const handleStep2 = () => onSetPin(pin, confirm);
+
+  // Auto-advance step 1 when 4 digits
+  useEffect(() => { if (pin.length === 4 && step === 1) setStep(2); }, [pin]);
+  // Auto-submit step 2 when 4 digits
+  useEffect(() => {
+    if (confirm.length === 4 && step === 2) handleStep2();
+  }, [confirm]);
+
+  return (
+    <div className="min-h-[calc(100vh-120px)] flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="w-16 h-16 rounded-3xl flex items-center justify-center mx-auto mb-5"
+            style={{ background: "var(--color-accent-subtle)" }}>
+            <ShieldCheck size={28} style={{ color: "var(--color-accent)" }} />
+          </div>
+          <h2 className="text-[20px] font-bold mb-1.5"
+            style={{ color: "var(--color-text-primary)" }}>
+            Protect your stock journal
+          </h2>
+          <p className="text-[13px]" style={{ color: "var(--color-text-secondary)" }}>
+            Set a 4-digit PIN to keep your cost data private
+          </p>
+        </div>
+
+        <div className="bg-white rounded-3xl border p-6 space-y-5 shadow-sm"
+          style={{ borderColor: "var(--color-border)" }}>
+          {step === 1 ? (
+            <PinInput
+              key="set"
+              value={pin}
+              onChange={(v) => { setPin(v); clearError(); }}
+              onSubmit={handleStep1}
+              label="Choose a 4-digit PIN"
+              autoFocus
+            />
+          ) : (
+            <PinInput
+              key="confirm"
+              value={confirm}
+              onChange={(v) => { setConfirm(v); clearError(); }}
+              onSubmit={handleStep2}
+              label="Confirm your PIN"
+              error={error}
+              autoFocus
+            />
+          )}
+
+          {step === 2 && (
+            <button onClick={handleStep2} disabled={confirm.length < 4 || loading}
+              className="w-full h-11 rounded-xl text-[14px] font-bold text-white flex items-center justify-center gap-2 disabled:opacity-40 hover:opacity-90 transition-all"
+              style={{ background: "var(--color-accent)" }}>
+              {loading
+                ? <><Loader2 size={15} className="animate-spin" /> Saving…</>
+                : <><ShieldCheck size={15} /> Set PIN & unlock</>
+              }
+            </button>
+          )}
+
+          {step === 2 && (
+            <button onClick={() => { setStep(1); setPin(""); setConfirm(""); clearError(); }}
+              className="w-full text-[12px] font-medium text-center hover:underline"
+              style={{ color: "var(--color-text-muted)" }}>
+              ← Choose a different PIN
+            </button>
+          )}
+
+          <p className="text-[11px] text-center leading-relaxed"
+            style={{ color: "var(--color-text-muted)" }}>
+            The PIN is stored locally on this device.<br />
+            You can change or remove it later from the journal.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Layout export ──────────────────────────────────────────────
+export default function StockLayout({ children }) {
+  const { status, hasPIN, pinError:error, working:loading, setPIN, unlocked,  unlock, clearError } = useStockLock();
+
+  if (!hasPIN) {
+    return <SetupScreen onSetPin={setPIN} error={error} loading={loading} clearError={clearError} />;
+  }
+
+  if (unlocked === false) {
+    return <LockScreen onUnlock={unlock} error={error} loading={loading} clearError={clearError} />;
+  }
+
+  // Unlocked — render the actual page
+  return <>{children}</>;
+}

--- a/frontend/app/dashboard/stock/page.jsx
+++ b/frontend/app/dashboard/stock/page.jsx
@@ -1,0 +1,508 @@
+"use client";
+// app/stock/page.jsx
+
+import { useState } from "react";
+import {
+  Plus,
+  TrendingUp,
+  Package,
+  Wallet,
+  Calendar,
+  Lock,
+  KeyRound,
+  Loader2,
+  ShieldCheck,
+} from "lucide-react";
+import { StockTable } from "./StockTable";
+import { StockEntryDrawer } from "./StockEntryForm";
+import {
+  useStockEntries,
+  useStockSummary,
+  useCreateStockEntry,
+  useUpdateStockEntry,
+  useDeleteStockEntry,
+} from "@/lib/hooks/useStock";
+import { useStockLock } from "@/lib/hooks/useStockLock";
+import { cn } from "@/lib/utils";
+import { Package2Icon } from "lucide-react";
+
+// ── Summary card ──────────────────────────────────────────────
+function SummaryCard({ icon: Icon, label, value, sub, color, loading }) {
+  return (
+    <div
+      className="bg-white rounded-2xl border p-5"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <p
+            className="text-[11px] font-semibold uppercase tracking-wider mb-1"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            {label}
+          </p>
+          {loading ? (
+            <div
+              className="h-7 w-24 rounded-lg animate-pulse"
+              style={{ background: "var(--color-border)" }}
+            />
+          ) : (
+            <p
+              className="text-[22px] font-bold truncate"
+              style={{ color: "var(--color-text-primary)" }}
+            >
+              {value}
+            </p>
+          )}
+          {sub && !loading && (
+            <p
+              className="text-[11px] mt-1"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              {sub}
+            </p>
+          )}
+        </div>
+        <div
+          className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+          style={{ background: `${color}18`, color }}
+        >
+          <Icon size={20} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatCurrency(val) {
+  return `K${Number(val ?? 0).toLocaleString("en-ZM", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+// ── PIN management modal ──────────────────────────────────────
+function PinManagementModal({ onClose, lock }) {
+  const [mode, setMode] = useState("menu"); // "menu" | "change" | "remove"
+  const [cur, setCur] = useState("");
+  const [next, setNext] = useState("");
+  const [conf, setConf] = useState("");
+  const [err, setErr] = useState(null);
+  const [done, setDone] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const handleChange = async () => {
+    setBusy(true);
+    setErr(null);
+    const ok = await lock.changePin(cur, next, conf);
+    setBusy(false);
+    if (ok) setDone(true);
+    else setErr(lock.error);
+  };
+
+  const handleRemove = async () => {
+    setBusy(true);
+    setErr(null);
+    const ok = await lock.removePin(cur);
+    setBusy(false);
+    if (ok) {
+      setDone(true);
+      setTimeout(onClose, 1500);
+    } else setErr(lock.error);
+  };
+
+  const inp =
+    "w-full h-10 px-3 rounded-xl border text-[13px] outline-none transition-all focus:border-[var(--color-accent)]";
+  const inpStyle = {
+    borderColor: "var(--color-border-md)",
+    background: "white",
+    color: "var(--color-text-primary)",
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/30 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div
+        className="relative bg-white rounded-3xl p-6 max-w-sm w-full shadow-2xl"
+        style={{ border: "1px solid var(--color-border)" }}
+      >
+        <div
+          className="w-12 h-12 rounded-2xl flex items-center justify-center mb-4"
+          style={{ background: "var(--color-accent-subtle)" }}
+        >
+          <ShieldCheck size={22} style={{ color: "var(--color-accent)" }} />
+        </div>
+
+        {mode === "menu" && (
+          <>
+            <h3
+              className="text-[16px] font-bold mb-1.5"
+              style={{ color: "var(--color-text-primary)" }}
+            >
+              PIN settings
+            </h3>
+            <p
+              className="text-[13px] mb-5"
+              style={{ color: "var(--color-text-secondary)" }}
+            >
+              Manage the PIN that protects your stock journal.
+            </p>
+            <div className="space-y-2">
+              <button
+                onClick={() => setMode("change")}
+                className="w-full h-11 rounded-xl border text-[13px] font-semibold transition-colors hover:bg-[var(--color-accent-subtle)] text-left px-4"
+                style={{
+                  borderColor: "var(--color-border-md)",
+                  color: "var(--color-text-primary)",
+                }}
+              >
+                Change PIN
+              </button>
+              <button
+                onClick={() => setMode("remove")}
+                className="w-full h-11 rounded-xl border text-[13px] font-semibold transition-colors hover:bg-[var(--color-danger-bg)] text-left px-4"
+                style={{
+                  borderColor: "var(--color-border-md)",
+                  color: "var(--color-danger)",
+                }}
+              >
+                Remove PIN protection
+              </button>
+            </div>
+            <button
+              onClick={onClose}
+              className="w-full mt-3 text-[12px] font-medium text-center hover:underline"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              Cancel
+            </button>
+          </>
+        )}
+
+        {mode === "change" && !done && (
+          <>
+            <h3
+              className="text-[16px] font-bold mb-4"
+              style={{ color: "var(--color-text-primary)" }}
+            >
+              Change PIN
+            </h3>
+            <div className="space-y-3">
+              <input
+                type="password"
+                maxLength={4}
+                value={cur}
+                onChange={(e) => setCur(e.target.value)}
+                placeholder="Current PIN"
+                className={inp}
+                style={inpStyle}
+              />
+              <input
+                type="password"
+                maxLength={4}
+                value={next}
+                onChange={(e) => setNext(e.target.value)}
+                placeholder="New PIN (4 digits)"
+                className={inp}
+                style={inpStyle}
+              />
+              <input
+                type="password"
+                maxLength={4}
+                value={conf}
+                onChange={(e) => setConf(e.target.value)}
+                placeholder="Confirm new PIN"
+                className={inp}
+                style={inpStyle}
+              />
+              {err && (
+                <p
+                  className="text-[12px]"
+                  style={{ color: "var(--color-danger)" }}
+                >
+                  {err}
+                </p>
+              )}
+            </div>
+            <div className="flex gap-2 mt-4">
+              <button
+                onClick={() => {
+                  setMode("menu");
+                  setErr(null);
+                }}
+                className="flex-1 h-10 rounded-xl border text-[13px] font-semibold hover:bg-[var(--color-bg)] transition-colors"
+                style={{
+                  borderColor: "var(--color-border-md)",
+                  color: "var(--color-text-secondary)",
+                }}
+              >
+                Back
+              </button>
+              <button
+                onClick={handleChange}
+                disabled={busy || !cur || !next || !conf}
+                className="flex-1 h-10 rounded-xl text-[13px] font-bold text-white disabled:opacity-40 transition-all"
+                style={{ background: "var(--color-accent)" }}
+              >
+                {busy ? "Saving…" : "Update PIN"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {mode === "remove" && !done && (
+          <>
+            <h3
+              className="text-[16px] font-bold mb-2"
+              style={{ color: "var(--color-text-primary)" }}
+            >
+              Remove PIN
+            </h3>
+            <p
+              className="text-[13px] mb-4"
+              style={{ color: "var(--color-text-secondary)" }}
+            >
+              Enter your current PIN to confirm removal. The journal will no
+              longer be protected.
+            </p>
+            <input
+              type="password"
+              maxLength={4}
+              value={cur}
+              onChange={(e) => setCur(e.target.value)}
+              placeholder="Current PIN"
+              className={inp}
+              style={inpStyle}
+            />
+            {err && (
+              <p
+                className="text-[12px] mt-2"
+                style={{ color: "var(--color-danger)" }}
+              >
+                {err}
+              </p>
+            )}
+            <div className="flex gap-2 mt-4">
+              <button
+                onClick={() => {
+                  setMode("menu");
+                  setErr(null);
+                }}
+                className="flex-1 h-10 rounded-xl border text-[13px] font-semibold hover:bg-[var(--color-bg)] transition-colors"
+                style={{
+                  borderColor: "var(--color-border-md)",
+                  color: "var(--color-text-secondary)",
+                }}
+              >
+                Back
+              </button>
+              <button
+                onClick={handleRemove}
+                disabled={busy || !cur}
+                className="flex-1 h-10 rounded-xl text-[13px] font-bold text-white disabled:opacity-40 transition-all"
+                style={{ background: "var(--color-danger)" }}
+              >
+                {busy ? "Removing…" : "Remove PIN"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {done && (
+          <div className="text-center py-4">
+            <p
+              className="text-[15px] font-semibold"
+              style={{ color: "var(--color-success)" }}
+            >
+              {mode === "remove" ? "PIN removed" : "PIN updated!"}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Page ───────────────────────────────────────────────────────
+export default function StockJournalPage() {
+  const lock = useStockLock();
+
+  // Filters
+  const [filters, setFilters] = useState({
+    search: "",
+    dateFrom: "",
+    dateTo: "",
+    includeAdjustments: false,
+    page: 1,
+    limit: 25,
+  });
+
+  // Drawer state
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editEntry, setEditEntry] = useState(null);
+  const [pinModal, setPinModal] = useState(false);
+
+  // Hooks
+  const { entries, total, isLoading, isRefreshing, mutate } =
+    useStockEntries(filters);
+  const { summary, isLoading: summaryLoading } = useStockSummary();
+  const { create, loading: creating, fieldErrors } = useCreateStockEntry();
+  const { update, loading: updating } = useUpdateStockEntry();
+  const { remove, loading: deleting } = useDeleteStockEntry();
+  console.log("summary",summary)
+
+  const openAdd = () => {
+    setEditEntry(null);
+    setDrawerOpen(true);
+  };
+  const openEdit = (entry) => {
+    setEditEntry(entry);
+    setDrawerOpen(true);
+  };
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    setEditEntry(null);
+  };
+
+  const handleSave = async (payload) => {
+    let ok;
+    if (editEntry) {
+      ok = await update(editEntry.id, payload);
+    } else {
+      ok = await create(payload);
+    }
+    if (ok) closeDrawer();
+  };
+
+  const handleDelete = async (id) => {
+    await remove(id);
+  };
+
+  return (
+    <div>
+      {/* Page header */}
+      <div className="flex items-start justify-between gap-4 mb-6 flex-wrap">
+        <div>
+          <h1
+            className="text-[22px] font-semibold tracking-tight"
+            style={{ color: "var(--color-text-primary)" }}
+          >
+            Stock journal
+          </h1>
+          <p
+            className="text-[13px] mt-0.5"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            Log and track every stock purchase and adjustment
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Lock now */}
+          <button
+            onClick={() => lock.lock()}
+            className="flex items-center gap-1.5 h-9 px-3 rounded-xl border text-[12px] font-medium transition-colors hover:bg-[var(--color-bg)]"
+            style={{
+              borderColor: "var(--color-border-md)",
+              color: "var(--color-text-secondary)",
+            }}
+            title="Lock journal"
+          >
+            <Lock size={13} /> Lock
+          </button>
+          {/* PIN settings */}
+          {lock.hasPin && (
+            <button
+              onClick={() => setPinModal(true)}
+              className="flex items-center gap-1.5 h-9 px-3 rounded-xl border text-[12px] font-medium transition-colors hover:bg-[var(--color-bg)]"
+              style={{
+                borderColor: "var(--color-border-md)",
+                color: "var(--color-text-secondary)",
+              }}
+              title="PIN settings"
+            >
+              <KeyRound size={13} /> PIN
+            </button>
+          )}
+          {/* New entry */}
+          <button
+            onClick={openAdd}
+            className="flex items-center gap-2 h-9 px-4 rounded-xl text-[13px] font-bold text-white transition-all hover:opacity-90"
+            style={{ background: "var(--color-accent)" }}
+          >
+            <Plus size={15} /> Log purchase
+          </button>
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <SummaryCard
+          icon={Wallet}
+          label="Total spend"
+          value={formatCurrency(summary?.totalSpend)}
+          sub="All time"
+          color="#0057ff"
+          loading={summaryLoading}
+        />
+        <SummaryCard
+          icon={Package2Icon}
+          label="Units Pending"
+          value={(summary?.pendingCount).toLocaleString()}
+          sub={"Pending purchases"}
+          color="#7c3aed"
+          loading={summaryLoading}
+        />
+        <SummaryCard
+          icon={Package}
+          label="Units purchased"
+          value={(summary?.totalUnits ?? 0).toLocaleString()}
+          sub="All products"
+          color="#059669"
+          loading={summaryLoading}
+        />
+        <SummaryCard
+          icon={TrendingUp}
+          label="Total entries"
+          value={(summary?.entryCount ?? 0).toLocaleString()}
+          sub="Journal records"
+          color="#d97706"
+          loading={summaryLoading}
+        />
+      </div>
+
+      {/* Table */}
+      <StockTable
+        entries={entries}
+        total={total}
+        isLoading={isLoading}
+        isRefreshing={isRefreshing}
+        filters={filters}
+        onFilterChange={setFilters}
+        onEdit={openEdit}
+        onDelete={handleDelete}
+        deleteLoading={deleting}
+        page={filters.page}
+        limit={filters.limit}
+        onPageChange={(p) => setFilters((f) => ({ ...f, page: p }))}
+      />
+
+      {/* Entry drawer */}
+      <StockEntryDrawer
+        open={drawerOpen}
+        entry={editEntry}
+        onClose={closeDrawer}
+        onSave={handleSave}
+        loading={creating || updating}
+        fieldErrors={fieldErrors}
+      />
+
+      {/* PIN management modal */}
+      {pinModal && (
+        <PinManagementModal lock={lock} onClose={() => setPinModal(false)} />
+      )}
+    </div>
+  );
+}

--- a/frontend/components/cart/CartDrawer.jsx
+++ b/frontend/components/cart/CartDrawer.jsx
@@ -108,13 +108,13 @@ function GuestBanner({ onClose }) {
         </p>
       </div>
       <div className="flex gap-2">
-        <Link href="/auth/sign-in" onClick={onClose} className="flex-1">
+        <Link href="/sign-in" onClick={onClose} className="flex-1">
           <button className="w-full h-9 rounded-xl bg-[var(--color-primary)] text-white text-[13px] font-semibold flex items-center justify-center gap-1.5 hover:bg-[var(--color-primary-hover)] transition-colors">
             <LogIn size={14} />
             Sign in
           </button>
         </Link>
-        <Link href="/auth/sign-up" onClick={onClose} className="flex-1">
+        <Link href="/sign-up" onClick={onClose} className="flex-1">
           <button className="w-full h-9 rounded-xl border border-[var(--color-border-md)] text-[var(--color-text-secondary)] text-[13px] font-medium flex items-center justify-center hover:bg-white transition-colors">
             Create account
           </button>

--- a/frontend/lib/hooks/useStock.js
+++ b/frontend/lib/hooks/useStock.js
@@ -1,0 +1,177 @@
+"use client";
+// client/lib/hooks/useStock.js
+import useSWR, { mutate as globalMutate } from "swr";
+import { useState, useCallback } from "react";
+import { apiClient, swrFetcher } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { toast } from "@/lib/store/toastStore";
+import useAuthStore from "@/lib/store/useAuthStore";
+
+const SWR_OPTS = {
+  revalidateOnFocus: true,
+  keepPreviousData: true,
+  shouldRetryOnError: false,
+};
+
+// ── useStockEntries — paginated list with filters ─────────────
+export function useStockEntries(filters = {}) {
+  const storeId = useAuthStore((s) => s.storeId);
+  const key = storeId
+    ? [
+        `/stores/${storeId}/stock`,
+        {
+          page: filters.page ?? 1,
+          limit: filters.limit ?? 25,
+          product_id: filters.productId ?? undefined,
+          date_from: filters.dateFrom ?? undefined,
+          date_to: filters.dateTo ?? undefined,
+          search: filters.search ?? undefined,
+        },
+      ]
+    : null;
+
+  const { data, error, isLoading, isValidating, mutate } = useSWR(
+    key,
+    swrFetcher,
+    SWR_OPTS
+  );
+
+  return {
+    entries: data?.data ?? [],
+    total: data?.meta?.total ?? 0,
+    isLoading,
+    isRefreshing: isValidating && !isLoading,
+    error,
+    mutate,
+  };
+}
+
+// ── useStockSummary — header summary cards ────────────────────
+export function useStockSummary(filters = {}) {
+  const storeId = useAuthStore((s) => s.storeId);
+  const key = storeId
+    ? [
+        `/stores/${storeId}/stock/summary`,
+        {
+          date_from: filters.dateFrom ?? undefined,
+          date_to: filters.dateTo ?? undefined,
+        },
+      ]
+    : null;
+
+  const { data, error, isLoading } = useSWR(key, swrFetcher, SWR_OPTS);
+  // console.log(data);
+
+  return {
+    summary: data?.data ?? { totalUnits: 0, totalSpend: 0, entryCount: 0, pendingCount: 0 },
+    isLoading,
+    error,
+  };
+}
+
+// ── useCreateStockEntry ───────────────────────────────────────
+export function useCreateStockEntry() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const [loading, setLoad] = useState(false);
+  const [errors, setErrs] = useState({});
+
+  const create = useCallback(
+    async (payload) => {
+      console.log("payload: ", payload)
+      if (!storeId) return null;
+      setLoad(true);
+      setErrs({});
+      try {
+        const result = await apiClient.post(
+          `/stores/${storeId}/stock`,
+          payload
+        );
+        // Revalidate both the list and the summary
+        globalMutate((k) => Array.isArray(k) && k[0]?.includes("/stock"));
+        toast.success("Stock entry logged");
+        return result?.data ?? null;
+      } catch (err) {
+        if (err instanceof ApiError && err.isValidation) {
+          const flat = {};
+          (err.details ?? []).forEach((d) => {
+            flat[d.field] = d.message;
+          });
+          setErrs(flat);
+          console.log(flat)
+          toast.error("Please fix the highlighted fields");
+        } else {
+          toast.error(
+            err instanceof ApiError ? err.message : "Failed to save entry"
+          );
+        }
+        return null;
+      } finally {
+        setLoad(false);
+      }
+    },
+    [storeId]
+  );
+
+  return { create, loading, errors };
+}
+
+// ── useUpdateStockEntry ───────────────────────────────────────
+export function useUpdateStockEntry() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const [loading, setLoad] = useState(false);
+
+  const update = useCallback(
+    async (entryId, payload) => {
+      if (!storeId) return null;
+      setLoad(true);
+      try {
+        const result = await apiClient.patch(
+          `/stores/${storeId}/stock/${entryId}`,
+          payload
+        );
+        globalMutate((k) => Array.isArray(k) && k[0]?.includes("/stock"));
+        toast.success("Entry updated");
+        return result?.data ?? null;
+      } catch (err) {
+        toast.error(
+          err instanceof ApiError ? err.message : "Failed to update entry"
+        );
+        return null;
+      } finally {
+        setLoad(false);
+      }
+    },
+    [storeId]
+  );
+
+  return { update, loading };
+}
+
+// ── useDeleteStockEntry ───────────────────────────────────────
+export function useDeleteStockEntry() {
+  const storeId = useAuthStore((s) => s.storeId);
+  const [loading, setLoad] = useState(false);
+
+  const remove = useCallback(
+    async (entryId) => {
+      if (!storeId) return false;
+      setLoad(true);
+      try {
+        await apiClient.delete(`/stores/${storeId}/stock/${entryId}`);
+        globalMutate((k) => Array.isArray(k) && k[0]?.includes("/stock"));
+        toast.success("Entry deleted");
+        return true;
+      } catch (err) {
+        toast.error(
+          err instanceof ApiError ? err.message : "Failed to delete entry"
+        );
+        return false;
+      } finally {
+        setLoad(false);
+      }
+    },
+    [storeId]
+  );
+
+  return { remove, loading };
+}

--- a/frontend/lib/hooks/useStockLock.js
+++ b/frontend/lib/hooks/useStockLock.js
@@ -1,0 +1,157 @@
+"use client";
+// client/lib/hooks/useStockLock.js
+// ─────────────────────────────────────────────────────────────
+// Manages a client-side PIN lock for the stock journal page.
+//
+// HOW IT WORKS
+// ────────────
+// The PIN is stored as a SHA-256 hash in localStorage under the key
+// "stock-journal-pin-hash:{storeId}". The plaintext PIN never persists.
+//
+// "Locked" state is ephemeral React state — not localStorage.
+// This means:
+//   - Navigating away clears the unlocked state in memory
+//   - On return to the page, the lock screen shows again
+//   - A full page refresh also re-locks
+//   - The hash in localStorage only survives as long as the store
+//     owner wants a PIN (they can clear it from the settings UI)
+//
+// SECURITY NOTE
+// ─────────────
+// This is UI-level protection only — anyone who can open DevTools
+// can clear localStorage. It is NOT a substitute for backend auth.
+// Its purpose is to prevent casual shoulder-surfing and accidental
+// navigation to sensitive purchase cost data. For a harder lock,
+// the PIN should be stored server-side and verified via an API call.
+// ─────────────────────────────────────────────────────────────
+
+import { useState, useCallback, useEffect } from "react";
+import useAuthStore from "@/lib/store/useAuthStore";
+
+const STORAGE_KEY = (storeId) => `stock-journal-pin-hash:${storeId}`;
+
+// SHA-256 hash of a string using the Web Crypto API (available in all modern browsers)
+async function sha256(text) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(text);
+  const hashBuf = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function useStockLock() {
+  const storeId = useAuthStore((s) => s.storeId);
+
+  // Whether a PIN has been configured for this store
+  const [hasPIN, setHasPIN] = useState(false);
+  // Whether the current session is unlocked
+  const [unlocked, setUnlocked] = useState(false);
+  // Error message shown when wrong PIN is entered
+  const [pinError, setPinError] = useState("");
+  // Working state for async hash operations
+  const [working, setWorking] = useState(false);
+
+  // On mount (and when storeId changes): check whether a PIN has been set
+  useEffect(() => {
+    if (!storeId) return;
+    const stored = localStorage.getItem(STORAGE_KEY(storeId));
+    setHasPIN(Boolean(stored));
+    console.log(stored);
+    // If no PIN is set, grant access immediately
+    setUnlocked(false);
+  }, [storeId]);
+
+  // ── unlock(pin) ───────────────────────────────────────────
+  // Hashes the entered PIN and compares against the stored hash.
+  // Returns true on success, false on mismatch.
+  const unlock = useCallback(
+    async (pin) => {
+      if (!storeId || !pin.trim()) return false;
+      setWorking(true);
+      setPinError("");
+      try {
+        const entered = await sha256(pin.trim());
+        const stored = localStorage.getItem(STORAGE_KEY(storeId));
+        if (entered === stored) {
+          setUnlocked(true);
+          setPinError("");
+          return true;
+        } else {
+          setPinError("Incorrect PIN. Try again.");
+          return false;
+        }
+      } finally {
+        setWorking(false);
+      }
+    },
+    [storeId]
+  );
+
+  // ── setPIN(newPin) ────────────────────────────────────────
+  // Sets (or replaces) the PIN. Requires the current PIN to be
+  // entered first if one is already set (prevents someone
+  // changing the PIN while the screen is locked).
+  const setPIN = useCallback(
+    async (newPin, currentPin = null) => {
+      if (!storeId) return false;
+      setWorking(true);
+      setPinError("");
+      try {
+        // If a PIN is already set, verify the current one first
+        if (hasPIN && currentPin !== null) {
+          const currentHash = await sha256(currentPin.trim());
+          const stored = localStorage.getItem(STORAGE_KEY(storeId));
+          if (currentHash !== stored) {
+            setPinError("Current PIN is incorrect");
+            return false;
+          }
+        }
+
+        if (!newPin?.trim()) {
+          // Empty newPin = remove the PIN entirely
+          localStorage.removeItem(STORAGE_KEY(storeId));
+          setHasPIN(false);
+          setUnlocked(true);
+          return true;
+        }
+
+        const newHash = await sha256(newPin.trim());
+        localStorage.setItem(STORAGE_KEY(storeId), newHash);
+        setHasPIN(true);
+        setUnlocked(true); // setting a new PIN counts as unlocking
+        return true;
+      } finally {
+        setWorking(false);
+      }
+    },
+    [storeId, hasPIN]
+  );
+
+  // ── removePIN(currentPin) ─────────────────────────────────
+  const removePIN = useCallback(
+    async (currentPin) => {
+      return setPIN("", currentPin);
+    },
+    [setPIN]
+  );
+
+  // ── lock() ────────────────────────────────────────────────
+  // Manually lock the page (e.g. from a "Lock" button in the header)
+  const lock = useCallback(() => {
+    setUnlocked(false);
+    setPinError("");
+  }, []);
+
+  return {
+    hasPIN,
+    unlocked,
+    pinError,
+    working,
+    unlock,
+    setPIN,
+    removePIN,
+    lock,
+    clearError: () => setPinError(""),
+  };
+}

--- a/frontend/lib/nav.js
+++ b/frontend/lib/nav.js
@@ -1,5 +1,6 @@
 "use client";
 
+import { Package } from "lucide-react";
 import {
   LayoutGrid,
   ShoppingBag,
@@ -75,10 +76,10 @@ export const NAV_ITEMS = [
     section: "store",
   },
   {
-    key: "coming",
-    label: "Coming Soon",
-    href: "#",
-    icon: Palette,
+    key: "stock",
+    label: "Stock Journal",
+    href: "/dashboard/stock",
+    icon: Package,
     bottomTab: false,
     section: "store",
   },


### PR DESCRIPTION
Addde stock journal (stock entries) API, service, hooks, and UI

-backend: introduce stock journal endpoints and controller (stock.js, stockController.js) for listing, summarizing, creating, updating, deleting, and linking pending stock entries
-backend: implement stockService with support for listing entries, summary totals, linking pending entries to variants, and RPC-based variant stock increments
-backend: add validation rules for variants/stock in validate.js and validate.messages.js to support stock entry payloads and linking
-backend: document stock behaviour in [README.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (available_stock rules, reserved_stock guidance, and recommended flows)
-frontend: add stock journal UI under dashboard (/dashboard/stock) including StockEntryForm, StockTable, and PIN-based journal lock (useStockLock) with UX for logging purchases, adjustments, and linking pending entries
-frontend: add useStock hooks for listing, summary, creating/updating/deleting entries and link-pending action; add client-side invalidation after mutations
-frontend: wire stock counts and thresholds into product dashboards and editors (low-stock badges, stock fields, onboarding product defaults)
Notes:

-Stock entries support a "pending_product_name" workflow to credit stock retroactively when a product/variant is created or linked.
-PIN lock protects the journal UI; the plaintext PIN never persists client-side (currently only hashed storage).